### PR TITLE
FEI Risk Parameter Updates for Ethereum Aave v2 Market

### DIFF
--- a/content/aips/194D8F0A7E11-AIP-FEI-RISK-PARAMETER-UPDATE-AAVE-V2.md
+++ b/content/aips/194D8F0A7E11-AIP-FEI-RISK-PARAMETER-UPDATE-AAVE-V2.md
@@ -1,8 +1,8 @@
 ---
-title: Risk Parameter Updates for Ethereum Aave v2 Market
+title: FEI Risk Parameter Updates for Ethereum Aave v2 Market
 status: Proposed
 Author: [Llama](https://twitter.com/llama) [Matthew_Graham](https://twitter.com/Matthew_Graham_) [defijesus.eth](https://twitter.com/eldefijesus)
-shortDescription: Risk Parameter Updates for Ethereum Aave v2 Market
+shortDescription: FEI Risk Parameter Updates for Ethereum Aave v2 Market
 discussions: https://governance.aave.com/t/arc-risk-parameter-updates-for-ethereum-aave-v2-market/9393
 created: 2022-08-29
 ---

--- a/content/aips/194D8F0A7E11-AIP-FEI-RISK-PARAMETER-UPDATE-AAVE-V2.md
+++ b/content/aips/194D8F0A7E11-AIP-FEI-RISK-PARAMETER-UPDATE-AAVE-V2.md
@@ -1,7 +1,7 @@
 ---
 title: FEI Risk Parameter Updates for Ethereum Aave v2 Market
 status: Proposed
-Author: [Llama](https://twitter.com/llama) [Matthew_Graham](https://twitter.com/Matthew_Graham_) [defijesus.eth](https://twitter.com/eldefijesus)
+author: Llama (@llama), Matthew_Graham (@Matthew_Graham_), defijesus.eth (@eldefijesus)
 shortDescription: FEI Risk Parameter Updates for Ethereum Aave v2 Market
 discussions: https://governance.aave.com/t/arc-risk-parameter-updates-for-ethereum-aave-v2-market/9393
 created: 2022-08-29

--- a/content/aips/194D8F0A7E11-AIP-FEI-RISK-PARAMETER-UPDATE-AAVE-V2.md
+++ b/content/aips/194D8F0A7E11-AIP-FEI-RISK-PARAMETER-UPDATE-AAVE-V2.md
@@ -29,7 +29,7 @@ Snapshot found [here](https://snapshot.org/#/aave.eth/proposal/0x19df23070be999e
 
 ## Specification
 
-This proposal will freeze the lending market. 
+The proposal will freeze the FEI reserve on the pool, stopping supply of liquidity and borrowing.
 
 Borrowing Enabled → Disable 
 Lending Enabled → Disable 

--- a/content/aips/194D8F0A7E11-AIP-FEI-RISK-PARAMETER-UPDATE-AAVE-V2.md
+++ b/content/aips/194D8F0A7E11-AIP-FEI-RISK-PARAMETER-UPDATE-AAVE-V2.md
@@ -50,7 +50,7 @@ Deployment of the proposal payload can be found [here](https://etherscan.io/addr
 
 The repository of the payload can be found [here](https://github.com/llama-community/aave-risk-param-updates-fei)
  
-The proposal calls freezeReserve on the LendingPoolConfigurator (0x311Bb771e4F8952E6Da169b425E7e92d6Ac45756) targeting FEI (a0x956F47F50A910163D8BF957Cf5846D573E7f87CA).
+The proposal calls freezeReserve on the LendingPoolConfigurator (0x311Bb771e4F8952E6Da169b425E7e92d6Ac45756) targeting FEI (0x956F47F50A910163D8BF957Cf5846D573E7f87CA).
 
 The proposal calls the setReserveFactor function on the LendingPoolConfigurator (0x311Bb771e4F8952E6Da169b425E7e92d6Ac45756) for the FEI (0x956F47F50A910163D8BF957Cf5846D573E7f87CA) market with the new reserve Factor set to 10000 (100%).
 

--- a/content/aips/194D8F0A7E11-AIP-FEI-RISK-PARAMETER-UPDATE-AAVE-V2.md
+++ b/content/aips/194D8F0A7E11-AIP-FEI-RISK-PARAMETER-UPDATE-AAVE-V2.md
@@ -21,7 +21,7 @@ In response, this ARC proposes freezing the FEI market which will Disabling Depo
 
 # Motivation
 
-With the emergence of news that Tribe DAO intends to dissolve FEI and the Protocol Controlled Value (PCV) backing the stablecoin, there is a need to amend the FEI lending market in preparation of the risks to emerge with transition Tribe DAO to a terminal state.
+With the emergence of news that Tribe DAO intends to dissolve FEI and the Protocol Controlled Value (PCV) backing the stablecoin, there is a need to amend the FEI reserve in preparation of the risks to emerge with transition Tribe DAO to a terminal state.
 
 The details around how Tribe DAO will transition from current state to terminal state can be found [here](https://tribe.fei.money/t/tip-121-proposal-for-the-future-of-the-tribe-dao/4475).
 
@@ -32,7 +32,7 @@ Snapshot found [here](https://snapshot.org/#/aave.eth/proposal/0x19df23070be999e
 The proposal will freeze the FEI reserve on the pool, stopping supply of liquidity and borrowing.
 
 Borrowing Enabled → Disable 
-Lending Enabled → Disable 
+Deposits Enabled → Disable 
 
 Also,
 

--- a/content/aips/194D8F0A7E11-AIP-FEI-RISK-PARAMETER-UPDATE-AAVE-V2.md
+++ b/content/aips/194D8F0A7E11-AIP-FEI-RISK-PARAMETER-UPDATE-AAVE-V2.md
@@ -47,6 +47,8 @@ Test cases can be found: [Here](https://github.com/llama-community/aave-risk-par
 ## Implementation
 
 Deployment of the proposal payload can be found [here](TODO)
+
+The repository of the payload can be found [here](https://github.com/llama-community/aave-risk-param-updates-fei)
  
 The proposal calls freezeReserve on the LendingPoolConfigurator (0x311Bb771e4F8952E6Da169b425E7e92d6Ac45756) targeting FEI (a0x956F47F50A910163D8BF957Cf5846D573E7f87CA).
 

--- a/content/aips/194D8F0A7E11-AIP-FEI-RISK-PARAMETER-UPDATE-AAVE-V2.md
+++ b/content/aips/194D8F0A7E11-AIP-FEI-RISK-PARAMETER-UPDATE-AAVE-V2.md
@@ -46,7 +46,7 @@ Test cases can be found: [Here](https://github.com/llama-community/aave-risk-par
 
 ## Implementation
 
-Deployment of the proposal payload can be found [here](TODO)
+Deployment of the proposal payload can be found [here](https://etherscan.io/address/0xb8fe2a2104afb975240d3d32a7823a01cb74639f#code)
 
 The repository of the payload can be found [here](https://github.com/llama-community/aave-risk-param-updates-fei)
  

--- a/content/aips/AAACDD612A65-AIP-RISK-PARAMETER-UPDATE-AAVE-V2.md
+++ b/content/aips/AAACDD612A65-AIP-RISK-PARAMETER-UPDATE-AAVE-V2.md
@@ -1,0 +1,57 @@
+---
+title: Risk Parameter Updates for Ethereum Aave v2 Market
+status: Proposed
+Author: [Llama](https://twitter.com/llama) [Matthew_Graham](https://twitter.com/Matthew_Graham_) [defijesus.eth](https://twitter.com/eldefijesus)
+shortDescription: Risk Parameter Updates for Ethereum Aave v2 Market
+discussions: https://governance.aave.com/t/arc-risk-parameter-updates-for-ethereum-aave-v2-market/9393
+created: 2022-08-29
+---
+
+# Simple Summary
+
+In response to Tribe DAO’s proposal to enter a terminal state, this ARC proposes disabling Deposits, disabling Borrowing and route 100% of the interest paid by FEI borrowers to the Reserve Factor.
+
+# Abstract
+
+Tribe DAO is dissolving the DAO’s assets and TRIBE governance token. As a result, FEI will become backed 1:1 with DAI and redeemable 1FEI:1DAI. With Tribe DAO transitioning into a terminal state, the FEI stablecoin will overtime be redeemed for DAI.
+
+As FEI is redeemed for DAI, over time FEI’s circulating supply and liquidity will fall away. Without sufficient liquidity, liquidations can not be performed efficiently which creates a risk for the Ethereum Aave v2 market.
+
+In response, this ARC proposes freezing the FEI market which will Disabling Deposits, Disabling Borrowing and increase the Reserve Factor from 20% to 100%. Users will still be able to redeem aFEI and repay debt. 
+
+# Motivation
+
+With the emergence of news that Tribe DAO intends to dissolve FEI and the Protocol Controlled Value (PCV) backing the stablecoin, there is a need to amend the FEI lending market in preparation of the risks to emerge with transition Tribe DAO to a terminal state.
+
+The details around how Tribe DAO will transition from current state to terminal state can be found [here](https://tribe.fei.money/t/tip-121-proposal-for-the-future-of-the-tribe-dao/4475).
+
+Snapshot found [here](https://snapshot.org/#/aave.eth/proposal/0x19df23070be999efbb7caf6cd35c320eb74dd119bcb15d003dc2e82c2bbd0d94). 
+
+## Specification
+
+This proposal will freeze the lending market. 
+
+Borrowing Enabled → Disable 
+Lending Enabled → Disable 
+
+Also,
+
+Reserve Factor 20% → 100%
+
+## Test Cases
+
+This proposal has been tested and peer reviewed by [Bored Ghost Developing](https://twitter.com/bgdlabs).
+
+Test cases can be found: [Here](https://github.com/llama-community/aave-risk-param-updates-fei/blob/main/src/test/ValidationFeiRiskParamsUpdate.sol)
+
+## Implementation
+
+Deployment of the proposal payload can be found [here](TODO)
+ 
+The proposal calls freezeReserve on the LendingPoolConfigurator (0x311Bb771e4F8952E6Da169b425E7e92d6Ac45756) targeting FEI (a0x956F47F50A910163D8BF957Cf5846D573E7f87CA).
+
+The proposal calls the setReserveFactor function on the LendingPoolConfigurator (0x311Bb771e4F8952E6Da169b425E7e92d6Ac45756) for the FEI (0x956F47F50A910163D8BF957Cf5846D573E7f87CA) market with the new reserve Factor set to 10000 (100%).
+
+# Copyright
+
+Copyright and related rights waived via CC0.


### PR DESCRIPTION
This includes an AIP describing the FEI risk parameter updates for Ethereum Aave v2 Market.
More details can be found on the governance forum: https://governance.aave.com/t/arc-risk-parameter-updates-for-ethereum-aave-v2-market/9393