### PR TITLE
chore(ipfs-hash): use proper commit message to ci is skipped

### DIFF
--- a/.github/workflows/upload-ipfs.yml
+++ b/.github/workflows/upload-ipfs.yml
@@ -58,7 +58,7 @@ jobs:
           else
             git checkout -b ipfs-hash/${{ github.sha }}
             git add .
-            git commit -am "fix(cache): add missing ipfs hashes"
+            git commit -am "chore(ipfs-hash): add missing ipfs hashes :robot:"
             git push origin ipfs-hash/${{ github.sha }}
             exit 0
           fi


### PR DESCRIPTION
by using `chore(ipfs-hash)` and
```
    if: |
      !contains(github.event.head_commit.message, 'chore(ipfs-hash)')
```
inside the action we will skip recurrent runs.